### PR TITLE
Autodetects user ip from expo now

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,7 +41,8 @@
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
         "react-native-svg": "15.12.1",
-        "react-native-web": "~0.21.0"
+        "react-native-web": "~0.21.0",
+        "react-native-worklets": "0.5.1"
       },
       "devDependencies": {
         "@types/react": "^19.2.14",
@@ -1384,7 +1385,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
       "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -10857,7 +10857,6 @@
       "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
       "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",
@@ -10882,7 +10881,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,8 @@
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-svg": "15.12.1",
-    "react-native-web": "~0.21.0"
+    "react-native-web": "~0.21.0",
+    "react-native-worklets": "0.5.1"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -5,10 +5,6 @@ import { AuthRequiredError, apiFetch, TIMEOUTS } from './errors';
 /**
  * Resolve the dev machine's host (IP) from Expo's runtime config.
  *
- * A physical device running the app already knows this host — it's the same
- * address it used to reach the Metro bundler — so we can derive the backend
- * URL automatically and never need the IP hardcoded in a .env file.
- *
  * Expo exposes this host under different fields depending on the run mode
  * (Expo Go vs. dev build) and SDK version, so we check each in turn.
  */

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -2,7 +2,37 @@ import Constants from 'expo-constants';
 import { supabase } from './supabase';
 import { AuthRequiredError, apiFetch, TIMEOUTS } from './errors';
 
+/**
+ * Resolve the dev machine's host (IP) from Expo's runtime config.
+ *
+ * A physical device running the app already knows this host — it's the same
+ * address it used to reach the Metro bundler — so we can derive the backend
+ * URL automatically and never need the IP hardcoded in a .env file.
+ *
+ * Expo exposes this host under different fields depending on the run mode
+ * (Expo Go vs. dev build) and SDK version, so we check each in turn.
+ */
+const getDevHost = (): string | null => {
+  const candidates = [
+    Constants.expoConfig?.hostUri,
+    (Constants as any).expoGoConfig?.debuggerHost,
+    (Constants as any).manifest2?.extra?.expoGo?.debuggerHost,
+    (Constants as any).manifest?.debuggerHost, // legacy fallback
+  ];
+
+  for (const candidate of candidates) {
+    const host = candidate?.split(':')[0]?.trim();
+    if (host) {
+      return host;
+    }
+  }
+
+  return null;
+};
+
 const getApiUrl = (): string => {
+  
+  // Explicit override (e.g. staging/prod) via app.json -> expo.extra.apiUrl
   if (Constants.expoConfig?.extra?.apiUrl) {
     return Constants.expoConfig.extra.apiUrl;
   }
@@ -10,12 +40,13 @@ const getApiUrl = (): string => {
   if (__DEV__) {
     const port = process.env.EXPO_PUBLIC_API_PORT || '8000';
 
-    const hostUri = Constants.expoConfig?.hostUri;
-    if (hostUri) {
-      const host = hostUri.split(':')[0];
+    // Auto-detect the dev machine's IP from Expo — no .env entry needed.
+    const host = getDevHost();
+    if (host) {
       return `http://${host}:${port}`;
     }
 
+    // Optional manual override, only used if auto-detection fails.
     const localIp = process.env.EXPO_PUBLIC_LOCAL_IP;
     if (localIp) {
       return `http://${localIp}:${port}`;
@@ -28,6 +59,9 @@ const getApiUrl = (): string => {
 };
 
 export const API_BASE_URL = getApiUrl();
+// WebSocket URL is derived from the (auto-detected) API host by default;
+// EXPO_PUBLIC_WS_URL only needs to be set to point WS at a different host/port.
+// Will be same ip as API_BASE_URL if not set in env.
 export const WS_URL = process.env.EXPO_PUBLIC_WS_URL ?? API_BASE_URL.replace(/^http/, 'ws');
 
 export const API_ENDPOINTS = {


### PR DESCRIPTION
This ticket (https://github.com/KarimJC/BrainBank/issues/52) makes it so that ip addresses don't need to be stored in an .env file anymore.

Acceptance criteria:

- Remove EXPO_PUBLIC_API_URL, EXPO_PUBLIC_WS_URL, and EXPO_PUBLIC_LOCAL_IP from frontend/.env.
- Run npm install
- Open app on your phone and on the web and see if you can query the backend from both.
